### PR TITLE
Add undo and redo controls with history limit

### DIFF
--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -51,6 +51,14 @@ export function Toolbar() {
     await actions.overwriteJson();
   }, [actions]);
 
+  const handleUndo = useCallback(() => {
+    actions.undo();
+  }, [actions]);
+
+  const handleRedo = useCallback(() => {
+    actions.redo();
+  }, [actions]);
+
   const handleFontFamilyChange = useCallback((fontFamily: string) => {
     actions.updateSettings({ fontFamily });
   }, [actions]);
@@ -109,6 +117,40 @@ export function Toolbar() {
           }}
         >
           📂 JSONファイルを開く
+        </button>
+
+        <button
+          onClick={handleUndo}
+          disabled={!state.canUndo}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: state.canUndo ? '#6c757d' : '#adb5bd',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: state.canUndo ? 'pointer' : 'not-allowed',
+            fontWeight: 'bold',
+            fontSize: '14px',
+          }}
+        >
+          ← 戻る
+        </button>
+
+        <button
+          onClick={handleRedo}
+          disabled={!state.canRedo}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: state.canRedo ? '#6c757d' : '#adb5bd',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: state.canRedo ? 'pointer' : 'not-allowed',
+            fontWeight: 'bold',
+            fontSize: '14px',
+          }}
+        >
+          進む →
         </button>
 
         {state.currentFile && (


### PR DESCRIPTION
## Summary
- track card operations with undo/redo stacks limited to 10 steps
- expose undo/redo actions and buttons with left/right arrow icons in the toolbar

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689d73a50ce48330b22d4e7821ec4663