### PR TITLE
feat: add undo and redo functionality

### DIFF
--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -146,6 +146,42 @@ export function Toolbar() {
             </button>
           </>
         )}
+
+        <button
+          onClick={actions.undo}
+          disabled={state.history.undoCount === 0}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: '#6c757d',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: state.history.undoCount === 0 ? 'not-allowed' : 'pointer',
+            fontWeight: 'bold',
+            fontSize: '14px',
+            opacity: state.history.undoCount === 0 ? 0.5 : 1,
+          }}
+        >
+          ↶ 戻る
+        </button>
+
+        <button
+          onClick={actions.redo}
+          disabled={state.history.redoCount === 0}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: '#6c757d',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: state.history.redoCount === 0 ? 'not-allowed' : 'pointer',
+            fontWeight: 'bold',
+            fontSize: '14px',
+            opacity: state.history.redoCount === 0 ? 0.5 : 1,
+          }}
+        >
+          ↷ 進む
+        </button>
       </div>
 
       {/* 2段目: ファイルパス情報 */}


### PR DESCRIPTION
## Summary
- add undo/redo history with max 10 steps for card edits, moves, and status changes
- add toolbar buttons to navigate backward and forward through history
- reset history stacks when loading new files

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689d74bfa0e0833083b6be1594406414