### PR TITLE
Add Markdown display toggle for cards

### DIFF
--- a/src/renderer/components/CardItem.tsx
+++ b/src/renderer/components/CardItem.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { Card, CardStatus } from '@/models';
 import { useApp } from '../contexts/AppContext';
 import * as Diff from 'diff';
+import { renderMarkdown } from '@/utils';
 
 // 差分表示コンポーネント
 interface DiffViewerProps {
@@ -421,15 +422,19 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onMoveCard, onM
         </div>
       ) : (
         <div>
-          <div style={{
-            whiteSpace: 'pre-wrap',
-            lineHeight: '1.5',
-            fontFamily: state.settings.fontFamily,
-            fontSize: `${state.settings.fontSize}px`,
-            wordWrap: 'break-word',
-            overflow: 'hidden',
-          }}>
-            {card.hasChanges ? (
+          <div
+            style={{
+              whiteSpace: 'pre-wrap',
+              lineHeight: '1.5',
+              fontFamily: state.settings.fontFamily,
+              fontSize: `${state.settings.fontSize}px`,
+              wordWrap: 'break-word',
+              overflow: 'hidden',
+            }}
+          >
+            {state.settings.renderMode === 'markdown' ? (
+              <div dangerouslySetInnerHTML={{ __html: renderMarkdown(card.content) }} />
+            ) : card.hasChanges ? (
               <DiffViewer original={card.originalContent} current={card.content} />
             ) : (
               card.content
@@ -453,21 +458,27 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onMoveCard, onM
               }}>
                 📝 初期内容:
               </div>
-              <div style={{
-                whiteSpace: 'pre-wrap',
-                lineHeight: '1.4',
-                fontFamily: state.settings.fontFamily,
-                fontSize: `${Math.max(state.settings.fontSize - 1, 11)}px`,
-                color: '#6c757d',
-                wordWrap: 'break-word',
-                overflow: 'hidden',
-              }}>
-                <DiffViewer 
-                  original={card.originalContent} 
-                  current={card.content} 
-                  showAdded={false}
-                  showRemoved={true}
-                />
+              <div
+                style={{
+                  whiteSpace: 'pre-wrap',
+                  lineHeight: '1.4',
+                  fontFamily: state.settings.fontFamily,
+                  fontSize: `${Math.max(state.settings.fontSize - 1, 11)}px`,
+                  color: '#6c757d',
+                  wordWrap: 'break-word',
+                  overflow: 'hidden',
+                }}
+              >
+                {state.settings.renderMode === 'markdown' ? (
+                  <div dangerouslySetInnerHTML={{ __html: renderMarkdown(card.originalContent) }} />
+                ) : (
+                  <DiffViewer
+                    original={card.originalContent}
+                    current={card.content}
+                    showAdded={false}
+                    showRemoved={true}
+                  />
+                )}
               </div>
             </div>
           )}

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -59,6 +59,10 @@ export function Toolbar() {
     actions.updateSettings({ fontSize });
   }, [actions]);
 
+  const handleRenderModeChange = useCallback((mode: 'text' | 'markdown') => {
+    actions.updateSettings({ renderMode: mode });
+  }, [actions]);
+
   const cardCounts = {
     total: state.cards.length,
     unprocessed: state.cards.filter(c => c.status === CardStatus.UNPROCESSED).length,
@@ -278,6 +282,23 @@ export function Toolbar() {
             <span style={{ fontSize: '14px', fontWeight: 'bold', color: '#495057' }}>
               ⚙️ 設定:
             </span>
+
+            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px' }}>
+              表示:
+              <select
+                value={state.settings.renderMode}
+                onChange={(e) => handleRenderModeChange(e.target.value as 'text' | 'markdown')}
+                style={{
+                  padding: '4px 8px',
+                  border: '1px solid #ccc',
+                  borderRadius: '4px',
+                  fontSize: '14px',
+                }}
+              >
+                <option value="text">テキスト</option>
+                <option value="markdown">Markdown</option>
+              </select>
+            </label>
 
             <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px' }}>
               フォント:

--- a/src/renderer/contexts/AppContext.tsx
+++ b/src/renderer/contexts/AppContext.tsx
@@ -19,6 +19,7 @@ interface AppState {
   settings: {
     fontFamily: string;
     fontSize: number;
+    renderMode: 'text' | 'markdown';
   };
   history: {
     undoCount: number;
@@ -75,6 +76,7 @@ const initialState: AppState = {
   settings: {
     fontFamily: 'system-ui, -apple-system, sans-serif',
     fontSize: 12,
+    renderMode: 'text',
   },
   history: {
     undoCount: 0,

--- a/src/utils/MarkdownRenderer.ts
+++ b/src/utils/MarkdownRenderer.ts
@@ -1,0 +1,54 @@
+export function renderMarkdown(text: string): string {
+  if (!text) return '';
+
+  const escapeHtml = (str: string): string =>
+    str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  const processInline = (str: string): string => {
+    let result = escapeHtml(str);
+    result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    result = result.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+    result = result.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    return result;
+  };
+
+  const lines = text.split(/\n/);
+  let html = '';
+  let inList = false;
+
+  const closeList = () => {
+    if (inList) {
+      html += '</ul>';
+      inList = false;
+    }
+  };
+
+  for (const line of lines) {
+    if (/^###\s+/.test(line)) {
+      closeList();
+      html += `<h3>${processInline(line.replace(/^###\s+/, ''))}</h3>`;
+    } else if (/^##\s+/.test(line)) {
+      closeList();
+      html += `<h2>${processInline(line.replace(/^##\s+/, ''))}</h2>`;
+    } else if (/^#\s+/.test(line)) {
+      closeList();
+      html += `<h1>${processInline(line.replace(/^#\s+/, ''))}</h1>`;
+    } else if (/^[-*]\s+/.test(line)) {
+      if (!inList) {
+        html += '<ul>';
+        inList = true;
+      }
+      html += `<li>${processInline(line.replace(/^[-*]\s+/, ''))}</li>`;
+    } else if (line.trim() === '') {
+      closeList();
+      html += '<br />';
+    } else {
+      closeList();
+      html += `<p>${processInline(line)}</p>`;
+    }
+  }
+
+  closeList();
+  return html;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './TextProcessor';
+export * from './MarkdownRenderer';


### PR DESCRIPTION
## Summary
- allow switching card content display between plain text and Markdown
- show Markdown rendering without diffs; include original content
- provide global setting in toolbar to choose display mode

## Testing
- `npm test -- --passWithNoTests`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d78f6ffa08330a2571ef49c055140