### PR TITLE
feat: add single-line card view and collapsible hierarchy

### DIFF
--- a/src/renderer/components/CardList.tsx
+++ b/src/renderer/components/CardList.tsx
@@ -113,16 +113,17 @@ export function CardList({ cards, height }: CardListProps) {
 
   // カードのサイズを推定する関数
   const getItemSize = useCallback((index: number) => {
-    // 基本サイズを計算
     const card = cards[index];
     if (!card) return 140;
 
-    // キャッシュされたサイズがあれば使用
+    if (state.settings.cardDisplayMode === 'single') {
+      return 60;
+    }
+
     if (itemSizes.current[index]) {
       return itemSizes.current[index];
     }
 
-    // 設定からフォントサイズを取得
     const fontSize = state.settings.fontSize || 14;
     const lineHeight = fontSize * 1.5;
     
@@ -229,7 +230,7 @@ export function CardList({ cards, height }: CardListProps) {
     // キャッシュに保存
     itemSizes.current[index] = totalHeight;
     return totalHeight;
-  }, [cards, state.settings.fontSize]);
+  }, [cards, state.settings.fontSize, state.settings.cardDisplayMode]);
 
   // サイズをリセットする関数
   const resetItemSize = useCallback((index: number) => {
@@ -270,7 +271,7 @@ export function CardList({ cards, height }: CardListProps) {
   // フォント設定が変更された時にサイズをリセット
   React.useEffect(() => {
     resetAllItemSizes();
-  }, [state.settings.fontSize, state.settings.fontFamily, resetAllItemSizes]);
+  }, [state.settings.fontSize, state.settings.fontFamily, state.settings.cardDisplayMode, resetAllItemSizes]);
 
   if (cards.length === 0) {
     return (

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -63,6 +63,10 @@ export function Toolbar() {
     actions.updateSettings({ renderMode: mode });
   }, [actions]);
 
+  const handleCardDisplayModeChange = useCallback((mode: 'full' | 'single') => {
+    actions.updateSettings({ cardDisplayMode: mode });
+  }, [actions]);
+
   const cardCounts = {
     total: state.cards.length,
     unprocessed: state.cards.filter(c => c.status === CardStatus.UNPROCESSED).length,
@@ -297,6 +301,23 @@ export function Toolbar() {
               >
                 <option value="text">テキスト</option>
                 <option value="markdown">Markdown</option>
+              </select>
+            </label>
+
+            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px' }}>
+              カード表示:
+              <select
+                value={state.settings.cardDisplayMode}
+                onChange={(e) => handleCardDisplayModeChange(e.target.value as 'full' | 'single')}
+                style={{
+                  padding: '4px 8px',
+                  border: '1px solid #ccc',
+                  borderRadius: '4px',
+                  fontSize: '14px',
+                }}
+              >
+                <option value="full">通常</option>
+                <option value="single">1行</option>
               </select>
             </label>
 


### PR DESCRIPTION
## Summary
- add global setting to toggle between full and single-line card display
- allow collapsing/expanding card hierarchies and filter out hidden descendants
- adjust card list sizing and toolbar controls for new view modes

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6ed5db4833093eee27b9133a11a