### PR TITLE
feat: collapse individual cards and persist state

### DIFF
--- a/src/models/SaveData.ts
+++ b/src/models/SaveData.ts
@@ -5,6 +5,7 @@ export interface SaveData {
   originalFile: string;
   timestamp: string;
   cards: Card[];
+  collapsedCardIds: string[];
   metadata?: {
     totalCards: number;
     lastModified: string;
@@ -18,4 +19,4 @@ export interface SaveDataValidationResult {
   warnings: string[];
 }
 
-export const SAVE_DATA_VERSION = '1.4.0';
+export const SAVE_DATA_VERSION = '1.5.0';

--- a/src/renderer/components/CardList.tsx
+++ b/src/renderer/components/CardList.tsx
@@ -99,6 +99,10 @@ function CardRow({ index, style, data }: CardRowProps) {
             // 階層変更時に全体サイズをリセット
             resetAllItemSizes();
           }}
+          onToggleCollapse={() => {
+            // 折りたたみ状態変更時に全体サイズをリセット
+            resetAllItemSizes();
+          }}
         />
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
## Summary
- allow collapsing or expanding individual cards by clicking the card header
- store collapsed card IDs in JSON save data and restore them on load
- adjust card spacing when collapsed and reset list layout

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dcb5e894083309a408ea126a03d68