### PR TITLE
feat: add card display toggle

### DIFF
--- a/src/renderer/components/CardItem.tsx
+++ b/src/renderer/components/CardItem.tsx
@@ -50,6 +50,7 @@ interface CardItemProps {
   onIndentCard?: (cardId: string) => void;
   onOutdentCard?: (cardId: string) => void;
   index: number;
+  onToggleCardDisplayMode?: (cardId: string) => void;
 }
 
 const STATUS_COLORS = {
@@ -86,7 +87,7 @@ const DISPLAY_ATTRIBUTE_COLORS = {
   [DisplayAttribute.MISCELLANEOUS]: '#f3e8ff', // 薄い紫（雑記）
 };
 
-export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribute, onMoveCard, onMoveCardToPosition, onIndentCard, onOutdentCard, index }: CardItemProps) {
+export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribute, onMoveCard, onMoveCardToPosition, onIndentCard, onOutdentCard, index, onToggleCardDisplayMode }: CardItemProps) {
   const { state, actions } = useApp();
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(card.content);
@@ -95,6 +96,7 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribu
   const summaryLine = (card.contents || '').split('\n')[0];
   const hasChildren = state.cardManager.getChildCards(card.id).length > 0;
   const isCollapsed = state.collapsedCardIds.has(card.id);
+  const cardDisplayMode = state.cardDisplayModes[card.id] || state.settings.cardDisplayMode;
   const handleToggleCollapse = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     actions.toggleCollapse(card.id);
@@ -712,6 +714,22 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribu
           gap: '8px',
           alignItems: 'center',
         }}>
+          {onToggleCardDisplayMode && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onToggleCardDisplayMode(card.id); }}
+              style={{
+                padding: '2px 6px',
+                border: '1px solid #ccc',
+                borderRadius: '4px',
+                backgroundColor: '#f8f9fa',
+                cursor: 'pointer',
+                fontSize: '11px',
+              }}
+              title="表示切替"
+            >
+              {cardDisplayMode === 'single' ? '通常' : '1行'}
+            </button>
+          )}
           {onUpdateAttribute && (
             <>
               <select
@@ -857,16 +875,16 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribu
         <div>
           <div
             style={{
-              whiteSpace: state.settings.cardDisplayMode === 'single' ? 'nowrap' : 'pre-wrap',
+              whiteSpace: cardDisplayMode === 'single' ? 'nowrap' : 'pre-wrap',
               lineHeight: '1.5',
               fontFamily: state.settings.fontFamily,
               fontSize: `${state.settings.fontSize}px`,
               wordWrap: 'break-word',
               overflow: 'hidden',
-              textOverflow: state.settings.cardDisplayMode === 'single' ? 'ellipsis' : undefined,
+              textOverflow: cardDisplayMode === 'single' ? 'ellipsis' : undefined,
             }}
           >
-            {state.settings.cardDisplayMode === 'single'
+            {cardDisplayMode === 'single'
               ? summaryLine
               : state.settings.renderMode === 'markdown'
                 ? <div dangerouslySetInnerHTML={{ __html: renderMarkdown(card.content) }} />
@@ -875,7 +893,7 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribu
                   : card.content}
           </div>
 
-          {state.settings.cardDisplayMode !== 'single' && card.hasChanges && (
+          {cardDisplayMode !== 'single' && card.hasChanges && (
             <div style={{
               marginTop: '12px',
               padding: '8px',
@@ -917,11 +935,11 @@ export function CardItem({ card, isSelected, onSelect, onUpdate, onUpdateAttribu
             </div>
           )}
 
-          {state.settings.cardDisplayMode !== 'single' && renderAttributeSpecificContent()}
+          {cardDisplayMode !== 'single' && renderAttributeSpecificContent()}
         </div>
       )}
 
-      {state.settings.cardDisplayMode !== 'single' && (
+      {cardDisplayMode !== 'single' && (
         <div style={{
           fontSize: '11px',
           color: '#999',

--- a/src/renderer/components/CardList.tsx
+++ b/src/renderer/components/CardList.tsx
@@ -242,7 +242,8 @@ export function CardList({ cards, height }: CardListProps) {
     if (itemSizes.current[index]) {
       delete itemSizes.current[index];
       if (listRef.current) {
-        listRef.current.resetAfterIndex(index);
+        // Force react-window to recalculate sizes immediately
+        listRef.current.resetAfterIndex(index, true);
       }
     }
   }, []);
@@ -251,7 +252,8 @@ export function CardList({ cards, height }: CardListProps) {
   const resetAllItemSizes = useCallback(() => {
     itemSizes.current = [];
     if (listRef.current) {
-      listRef.current.resetAfterIndex(0);
+      // Force a full recompute so expanded cards reposition correctly
+      listRef.current.resetAfterIndex(0, true);
     }
   }, []);
 
@@ -260,7 +262,8 @@ export function CardList({ cards, height }: CardListProps) {
     if (itemSizes.current[index] !== actualHeight) {
       itemSizes.current[index] = actualHeight;
       if (listRef.current) {
-        listRef.current.resetAfterIndex(index);
+        // Update layout for the measured item immediately
+        listRef.current.resetAfterIndex(index, true);
       }
     }
   }, []);

--- a/src/renderer/components/CardList.tsx
+++ b/src/renderer/components/CardList.tsx
@@ -26,11 +26,12 @@ interface CardRowProps {
     resetItemSize: (index: number) => void;
     resetAllItemSizes: () => void;
     updateItemSize: (index: number, height: number) => void;
+    onToggleCardDisplayMode: (cardId: string, index: number) => void;
   };
 }
 
 function CardRow({ index, style, data }: CardRowProps) {
-  const { cards, selectedCardId, onSelect, onUpdate, onUpdateAttribute, onMoveCard, onMoveCardToPosition, onIndentCard, onOutdentCard, resetItemSize, resetAllItemSizes, updateItemSize } = data;
+  const { cards, selectedCardId, onSelect, onUpdate, onUpdateAttribute, onMoveCard, onMoveCardToPosition, onIndentCard, onOutdentCard, resetItemSize, resetAllItemSizes, updateItemSize, onToggleCardDisplayMode } = data;
   const card = cards[index];
   const rowRef = React.useRef<HTMLDivElement>(null);
 
@@ -99,6 +100,9 @@ function CardRow({ index, style, data }: CardRowProps) {
             // 階層変更時に全体サイズをリセット
             resetAllItemSizes();
           }}
+          onToggleCardDisplayMode={(cardId) => {
+            onToggleCardDisplayMode(cardId, index);
+          }}
         />
       </ErrorBoundary>
     </div>
@@ -116,7 +120,8 @@ export function CardList({ cards, height }: CardListProps) {
     const card = cards[index];
     if (!card) return 140;
 
-    if (state.settings.cardDisplayMode === 'single') {
+    const mode = state.cardDisplayModes[card.id] || state.settings.cardDisplayMode;
+    if (mode === 'single') {
       return 60;
     }
 
@@ -230,7 +235,7 @@ export function CardList({ cards, height }: CardListProps) {
     // キャッシュに保存
     itemSizes.current[index] = totalHeight;
     return totalHeight;
-  }, [cards, state.settings.fontSize, state.settings.cardDisplayMode]);
+  }, [cards, state.settings.fontSize, state.settings.cardDisplayMode, state.cardDisplayModes]);
 
   // サイズをリセットする関数
   const resetItemSize = useCallback((index: number) => {
@@ -301,6 +306,10 @@ export function CardList({ cards, height }: CardListProps) {
     resetItemSize,
     resetAllItemSizes,
     updateItemSize,
+    onToggleCardDisplayMode: (cardId: string, index: number) => {
+      actions.toggleCardDisplayMode(cardId);
+      resetItemSize(index);
+    },
   };
 
   return (

--- a/src/renderer/components/Toolbar.tsx
+++ b/src/renderer/components/Toolbar.tsx
@@ -306,19 +306,19 @@ export function Toolbar() {
 
             <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px' }}>
               カード表示:
-              <select
-                value={state.settings.cardDisplayMode}
-                onChange={(e) => handleCardDisplayModeChange(e.target.value as 'full' | 'single')}
+              <button
+                onClick={() => handleCardDisplayModeChange(state.settings.cardDisplayMode === 'single' ? 'full' : 'single')}
                 style={{
                   padding: '4px 8px',
                   border: '1px solid #ccc',
                   borderRadius: '4px',
+                  backgroundColor: '#f8f9fa',
+                  cursor: 'pointer',
                   fontSize: '14px',
                 }}
               >
-                <option value="full">通常</option>
-                <option value="single">1行</option>
-              </select>
+                {state.settings.cardDisplayMode === 'single' ? '通常' : '1行'}
+              </button>
             </label>
 
             <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px' }}>


### PR DESCRIPTION
## Summary
- allow switching card display mode globally via toolbar button
- enable per-card toggle between one-line and full view with first line summary
- track per-card display modes in context and update list layout accordingly

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689dd91393648330866357aca346846b